### PR TITLE
Fixes alias_method_chain Depreciated Warning

### DIFF
--- a/lib/cached_resource/caching.rb
+++ b/lib/cached_resource/caching.rb
@@ -6,7 +6,8 @@ module CachedResource
 
     included do
       class << self
-        alias_method_chain :find, :cache
+        alias_method :find_without_cache, :find
+        alias_method :find, :find_with_cache
       end
     end
 


### PR DESCRIPTION
A partial fix for [#395](https://github.com/Shopify/squirrel/issues/395) in squirrel

The method [alias_method_chain](http://apidock.com/rails/Module/alias_method_chain) was depreciated, and we were getting warnings from this gem that it was still in use. This PR fixes that in the same style as [this](https://github.com/rails/rails/pull/19434/files) PR from rails.

There is probably a more correct fix using Module#prepend, but that's beyond the scope of this PR.

@Shopify/plus-internal-dev 